### PR TITLE
Added support for Ubuntu/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,25 @@
 
 inspired by [nuttylamo's](https://github.com/nuttylmao) [Batch script](https://github.com/nuttylmao/Nutty-s-WebM-Converter) for converting video files to WebM files.
 
-## Run
-
+## Windows
+### Run
 Download latest release uns zip and run the `webm_conversion.exe` inside `webm_conversion` folder.
 
-## Bundle with PyInstaller (Windows only)
-
+### Bundle with PyInstaller (Windows only)
 ```
 python3 -m pip install -r requirements.txt
 python3 -m pip install pyinstaller
 python3 -m PyInstaller --noconfirm webm_converter.spec
+```
+
+## Ubuntu/Linux
+### Install
+```
+sudo apt install ffmpeg
+python3 -m pip install -r requirements.txt
+```
+
+### Run
+```
+python3 webm_converter.py
 ```

--- a/model.py
+++ b/model.py
@@ -121,7 +121,7 @@ class Model():
 
     def start_ffmpeg_conversion(self):
         if sys.platform.startswith('win32'):
-            process = subprocess.Popen(["ffmpeg.exe\\ffmpeg.exe", "-i", self.input_file_path_string, "-c:v", "libvpx-vp9", "-pix_fmt", "yuva420p", "-crf", "15", "-b:v", "2M", self.output_file_path_string])
+            process = subprocess.Popen(["ffmpeg.exe", "-i", self.input_file_path_string, "-c:v", "libvpx-vp9", "-pix_fmt", "yuva420p", "-crf", "15", "-b:v", "2M", self.output_file_path_string])
         elif sys.platform.startswith('linux'):
             process = subprocess.Popen(["ffmpeg", "-i", self.input_file_path_string, "-c:v", "libvpx-vp9", "-pix_fmt", "yuva420p", "-crf", "15", "-b:v", "2M", self.output_file_path_string])
 

--- a/model.py
+++ b/model.py
@@ -14,6 +14,7 @@ import sys
 from consts import *
 from pathlib import Path
 from subprocess import check_output
+from sys import platform
 
 class JsonFileCreateException(Exception):
     """ raised when json model could not be created """
@@ -97,7 +98,7 @@ class Model():
 
     def get_output_file_path(self, input_file_path_string, output_file_directory_string):
         input_file_name = os.path.basename(input_file_path_string)
-        output_file_path_string = output_file_directory_string + "\\" + os.path.splitext(input_file_name)[0] + ".webm"
+        output_file_path_string = os.path.join(output_file_directory_string, os.path.splitext(input_file_name)[0] + ".webm")
         return output_file_path_string
 
     def convert_to_webm(self, input_file_path_string, output_file_path_string, log):
@@ -119,7 +120,11 @@ class Model():
         update_log_thread.start()
 
     def start_ffmpeg_conversion(self):
-        process = subprocess.Popen(["ffmpeg.exe\\ffmpeg.exe", "-i", self.input_file_path_string, "-c:v", "libvpx-vp9", "-pix_fmt", "yuva420p", "-crf", "15", "-b:v", "2M", self.output_file_path_string])
+        if sys.platform.startswith('win32'):
+            process = subprocess.Popen(["ffmpeg.exe\\ffmpeg.exe", "-i", self.input_file_path_string, "-c:v", "libvpx-vp9", "-pix_fmt", "yuva420p", "-crf", "15", "-b:v", "2M", self.output_file_path_string])
+        elif sys.platform.startswith('linux'):
+            process = subprocess.Popen(["ffmpeg", "-i", self.input_file_path_string, "-c:v", "libvpx-vp9", "-pix_fmt", "yuva420p", "-crf", "15", "-b:v", "2M", self.output_file_path_string])
+
         stdout, stderr = process.communicate()
         return_value = process.wait()
 


### PR DESCRIPTION
I added support for using the `webm_converter.py` script on Ubuntu/Linux with `ffmpeg` installed via the package manager. I also tested this version on Windows which led me to change `"ffmpeg.exe\\ffmpeg.exe"` to `"ffmpeg.exe"` in `model.py:123` because otherwise the script could not find the `ffmpeg.exe`. 

Bundling the app with PyInstaller was not successful on my system neither with the original version nor with my updated version because of some missing dll files.